### PR TITLE
Fix logging

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,6 +14,7 @@ object Dependencies {
     val http4s        = "0.18.23"
     val circe         = "0.11.1"
     val http4sExtend  = "0.0.43"
+    val logback       = "1.2.3"
 
     val scalaCheck    = "1.14.0"
     val scalaTest     = "3.0.7"
@@ -46,7 +47,8 @@ object Dependencies {
     "org.http4s"            %% "http4s-circe"         % versionOf.http4s        withSources(),
     "io.circe"              %% "circe-generic"        % versionOf.circe         withSources(),
     "io.circe"              %% "circe-literal"        % versionOf.circe         withSources(),
-    "com.github.barambani"  %% "http4s-extend"        % versionOf.http4sExtend  excludeAll(transitiveDependencies:_*) withSources()
+    "com.github.barambani"  %% "http4s-extend"        % versionOf.http4sExtend  excludeAll(transitiveDependencies:_*) withSources(),
+    "ch.qos.logback"        %  "logback-classic"      % versionOf.logback       withSources()
   )
 
   val testDependencies = Seq(

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <property name="PATTERN"
+              value="[%date{ISO8601}][%highlight(%-5level)][%green(%thread)][%cyan(%logger{36})] %msg%n"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>
+


### PR DESCRIPTION
I'm not sure if this was done on purpose, but it was missing a slf4j backend.
Below the difference with the proposed changes

Before
```sh
sbt run
...
[info] Running server.Main 
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

After
```sh
sbt run
...
[info] Running server.Main 
[2019-04-20 17:06:44,228][INFO ][run-main-0][o.h.b.c.nio1.NIO1SocketServerGroup] Service bound to address /127.0.0.1:8080
[2019-04-20 17:06:44,233][INFO ][run-main-0][org.http4s.server.blaze.BlazeBuilder] 
  _   _   _        _ _     
 | |_| |_| |_ _ __| | | ___
 | ' \  _|  _| '_ \_  _(_-<
 |_||_\__|\__| .__/ |_|/__/
             |_|
[2019-04-20 17:06:44,277][INFO ][run-main-0][org.http4s.server.blaze.BlazeBuilder] http4s v0.18.23 on blaze v0.12.13 started at http://127.0.0.1:8080/
```